### PR TITLE
Feature/scenario1 event crud

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -11,7 +11,7 @@ services:
       - redis
 
   postgres:
-    image: postgres:latest
+    image: postgres:16
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem "jbuilder"
 # gem "kredis"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       public_suffix (>= 2.0.2, < 7.0)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.21)
     benchmark (0.4.1)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
@@ -370,6 +371,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   better_errors
   binding_of_caller
   bootsnap

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -1,0 +1,15 @@
+class Admin::ApplicationController < ApplicationController
+  before_action :require_admin_login
+  helper_method :current_admin_user
+
+  private
+
+  def require_admin_login
+    return if session[:admin_user_id].present?
+    redirect_to new_admin_session_path, alert: "ログインしてください"
+  end
+
+  def current_admin_user
+    @current_admin_user ||= AdminUser.find_by(id: session[:admin_user_id])
+  end
+end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,55 +1,50 @@
-module Admin
-  class EventsController < ApplicationController
-    before_action :require_admin_login
-    before_action :set_event, only: %i[show edit update destroy]
+class Admin::EventsController < Admin::ApplicationController
+  def index
+    @events = Event.kept.order(created_at: :desc)
+  end
 
-    def index
-      @events = Event.order(created_at: :desc)
+  def show
+    @event = Event.kept.find(params[:id])
+  end
+
+  def new
+    @event = Event.new
+  end
+
+  def create
+    @event = Event.new(event_params)
+    if @event.save
+      redirect_to admin_events_path, notice: "イベントを登録しました"
+    else
+      flash.now[:alert] = "登録に失敗しました"
+      render :new, status: :unprocessable_entity
     end
+  end
 
-    def show
-      @event = Event.find(params[:id])
+  def edit
+    @event = Event.kept.find(params[:id])
+  end
+
+  def update
+    @event = Event.kept.find(params[:id])
+    if @event.update(event_params)
+      redirect_to admin_events_path, notice: "イベントを更新しました"
+    else
+      flash.now[:alert] = "更新に失敗しました"
+      render :edit, status: :unprocessable_entity
     end
+  end
 
-    def new
-      @event = Event.new
-    end
+  # 論理削除
+  def destroy
+    event = Event.kept.find(params[:id])
+    event.update!(discarded_at: Time.current)
+    redirect_to admin_events_path, notice: "イベントを削除しました"
+  end
 
-    def create
-      @event = Event.new(event_params)
-      if @event.save
-        redirect_to admin_event_path(@event), notice: "イベントを登録しました"
-      else
-        render :new, status: :unprocessable_entity
-      end
-    end
+  private
 
-    def edit
-      @event = Event.find(params[:id])
-    end
-
-    def update
-      if @event.update(event_params)
-        redirect_to admin_event_path(@event), notice: "イベントを更新しました"
-      else
-        render :edit, status: :unprocessable_entity
-      end
-    end
-
-    def destroy
-      @event = Event.find(params[:id])
-      @event.destroy
-      redirect_to admin_events_path, notice: "イベントを削除しました"
-    end
-
-    private
-
-    def set_event
-      @event = Event.find(params[:id])
-    end
-
-    def event_params
-      params.require(:event).permit(:title, :description, :held_on, :organizer_name, :target_department)
-    end
+  def event_params
+    params.require(:event).permit(:name, :held_on, :organizer, :target, :description)
   end
 end

--- a/app/controllers/admin/events_controller.rb
+++ b/app/controllers/admin/events_controller.rb
@@ -1,0 +1,55 @@
+module Admin
+  class EventsController < ApplicationController
+    before_action :require_admin_login
+    before_action :set_event, only: %i[show edit update destroy]
+
+    def index
+      @events = Event.order(created_at: :desc)
+    end
+
+    def show
+      @event = Event.find(params[:id])
+    end
+
+    def new
+      @event = Event.new
+    end
+
+    def create
+      @event = Event.new(event_params)
+      if @event.save
+        redirect_to admin_event_path(@event), notice: "イベントを登録しました"
+      else
+        render :new, status: :unprocessable_entity
+      end
+    end
+
+    def edit
+      @event = Event.find(params[:id])
+    end
+
+    def update
+      if @event.update(event_params)
+        redirect_to admin_event_path(@event), notice: "イベントを更新しました"
+      else
+        render :edit, status: :unprocessable_entity
+      end
+    end
+
+    def destroy
+      @event = Event.find(params[:id])
+      @event.destroy
+      redirect_to admin_events_path, notice: "イベントを削除しました"
+    end
+
+    private
+
+    def set_event
+      @event = Event.find(params[:id])
+    end
+
+    def event_params
+      params.require(:event).permit(:title, :description, :held_on, :organizer_name, :target_department)
+    end
+  end
+end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,0 +1,21 @@
+class Admin::SessionsController < ApplicationController
+  def new
+  end
+
+  def create
+    user = AdminUser.find_by(email: params[:email])
+
+    if user&.authenticate(params[:password])
+      session[:admin_user_id] = user.id
+      redirect_to admin_events_path, notice: "ログインしました"
+    else
+      flash.now[:alert] = "メールアドレスまたはパスワードが違います"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    reset_session
+    redirect_to new_admin_session_path, notice: "ログアウトしました"
+  end
+end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -1,8 +1,11 @@
-class Admin::SessionsController < ApplicationController
+class Admin::SessionsController < Admin::ApplicationController
+  skip_before_action :require_admin_login, only: %i[new create]
+
   def new
   end
 
   def create
+    Rails.logger.debug "PARAMS=#{params.to_unsafe_h}"
     user = AdminUser.find_by(email: params[:email])
 
     if user&.authenticate(params[:password])
@@ -15,7 +18,7 @@ class Admin::SessionsController < ApplicationController
   end
 
   def destroy
-    reset_session
+    session.delete(:admin_user_id)
     redirect_to new_admin_session_path, notice: "ログアウトしました"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,18 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  allow_browser versions: :modern
+  helper_method :current_admin_user, :admin_logged_in?
+
+  def current_admin_user
+    return nil unless session[:admin_user_id]
+    @current_admin_user ||= AdminUser.find_by(id: session[:admin_user_id])
+  end
+
+  def admin_logged_in?
+    current_admin_user.present?
+  end
+
+  def require_admin_login
+    return if admin_logged_in?
+    redirect_to new_admin_session_path, alert: "ログインしてください"
+  end
 end
+

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,10 @@
+class EventsController < ApplicationController
+  def index
+    @events = Event.order(created_at: :desc)
+    @events = Event.order(held_on: :desc)
+  end
+
+  def show
+    @event = Event.find(params[:id])
+  end
+end

--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -1,0 +1,9 @@
+class Public::EventsController < ApplicationController
+  def index
+    @events = Event.order(held_on: :desc, created_at: :desc)
+  end
+
+  def show
+    @event = Event.find(params[:id])
+  end
+end

--- a/app/controllers/public/events_controller.rb
+++ b/app/controllers/public/events_controller.rb
@@ -1,9 +1,9 @@
 class Public::EventsController < ApplicationController
   def index
-    @events = Event.order(held_on: :desc, created_at: :desc)
+    @events = Event.kept.order(held_on: :asc)
   end
 
   def show
-    @event = Event.find(params[:id])
+    @event = Event.kept.find(params[:id])
   end
 end

--- a/app/helpers/admin/events_helper.rb
+++ b/app/helpers/admin/events_helper.rb
@@ -1,0 +1,2 @@
+module Admin::EventsHelper
+end

--- a/app/helpers/admin/sessions_helper.rb
+++ b/app/helpers/admin/sessions_helper.rb
@@ -1,0 +1,2 @@
+module Admin::SessionsHelper
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/helpers/public/events_helper.rb
+++ b/app/helpers/public/events_helper.rb
@@ -1,0 +1,2 @@
+module Public::EventsHelper
+end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,6 @@
+class AdminUser < ApplicationRecord
+  has_secure_password
+
+  validates :email, presence: true, uniqueness: true
+  validates :name, presence: true
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ApplicationRecord
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,9 @@
 class Event < ApplicationRecord
+  validates :name, presence: true, length: { maximum: 100 }
+  validates :held_on, presence: true
+  validates :organizer, presence: true, length: { maximum: 100 }
+  validates :target, presence: true, length: { maximum: 100 }
+  validates :description, presence: true, length: { maximum: 1000 }
+
+  scope :kept, -> { where(discarded_at: nil) }
 end

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,0 +1,40 @@
+<%= form_with model: [:admin, @event], local: true do |f| %>
+  <% if @event.errors.any? %>
+    <div style="color: red;">
+      <ul>
+        <% @event.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <%= f.label :title, "イベント名" %><br>
+    <%= f.text_field :title %>
+  </div>
+
+  <div>
+    <%= f.label :description, "説明" %><br>
+    <%= f.text_area :description %>
+  </div>
+
+  <div>
+    <%= f.label :held_on, "開催日" %><br>
+    <%= f.date_field :held_on %>
+  </div>
+
+  <div>
+    <%= f.label :organizer_name, "主催者名" %><br>
+    <%= f.text_field :organizer_name %>
+  </div>
+
+  <div>
+    <%= f.label :target_department, "対象部署" %><br>
+    <%= f.text_field :target_department %>
+  </div>
+
+  <div>
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/events/_form.html.erb
+++ b/app/views/admin/events/_form.html.erb
@@ -1,22 +1,18 @@
-<%= form_with model: [:admin, @event], local: true do |f| %>
-  <% if @event.errors.any? %>
-    <div style="color: red;">
-      <ul>
-        <% @event.errors.full_messages.each do |msg| %>
-          <li><%= msg %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
-
-  <div>
-    <%= f.label :title, "イベント名" %><br>
-    <%= f.text_field :title %>
+<% if event.errors.any? %>
+  <div style="color: red;">
+    <p><%= event.errors.count %>件のエラーがあります</p>
+    <ul>
+      <% event.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+      <% end %>
+    </ul>
   </div>
+<% end %>
 
+<%= form_with model: [:admin, event] do |f| %>
   <div>
-    <%= f.label :description, "説明" %><br>
-    <%= f.text_area :description %>
+    <%= f.label :name, "イベント名" %><br>
+    <%= f.text_field :name %>
   </div>
 
   <div>
@@ -25,13 +21,18 @@
   </div>
 
   <div>
-    <%= f.label :organizer_name, "主催者名" %><br>
-    <%= f.text_field :organizer_name %>
+    <%= f.label :organizer, "主催" %><br>
+    <%= f.text_field :organizer %>
   </div>
 
   <div>
-    <%= f.label :target_department, "対象部署" %><br>
-    <%= f.text_field :target_department %>
+    <%= f.label :target, "対象" %><br>
+    <%= f.text_field :target %>
+  </div>
+
+  <div>
+    <%= f.label :description, "説明" %><br>
+    <%= f.text_area :description, rows: 5 %>
   </div>
 
   <div>

--- a/app/views/admin/events/edit.html.erb
+++ b/app/views/admin/events/edit.html.erb
@@ -1,0 +1,3 @@
+<h1>イベント編集</h1>
+<%= render "form" %>
+<%= link_to "戻る", admin_event_path(@event) %>

--- a/app/views/admin/events/edit.html.erb
+++ b/app/views/admin/events/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>イベント編集</h1>
-<%= render "form" %>
-<%= link_to "戻る", admin_event_path(@event) %>
+<%= render "form", event: @event %>
+<%= link_to "一覧へ戻る", admin_events_path %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,9 +1,7 @@
 <h1>イベント一覧（管理）</h1>
 <p>登録済みイベントを管理できます。</p>
 
-<p>
-  <%= link_to "新規イベント作成", new_admin_event_path %>
-</p>
+<p><%= link_to "新規イベント作成", new_admin_event_path %></p>
 
 <table>
   <thead>
@@ -17,12 +15,13 @@
   <tbody>
     <% @events.each do |event| %>
       <tr>
-        <td><%= event.title %></td>
+        <td><%= event.name %></td>
         <td><%= event.held_on %></td>
-        <td><%= l(event.created_at, format: :short) %></td>
+        <td><%= l(event.created_at) rescue event.created_at %></td>
         <td>
           <%= link_to "詳細", admin_event_path(event) %> |
-          <%= link_to "編集", edit_admin_event_path(event) %>
+          <%= link_to "編集", edit_admin_event_path(event) %> |
+          <%= link_to "削除", admin_event_path(event), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" } %>
         </td>
       </tr>
     <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -1,0 +1,30 @@
+<h1>イベント一覧（管理）</h1>
+<p>登録済みイベントを管理できます。</p>
+
+<p>
+  <%= link_to "新規イベント作成", new_admin_event_path %>
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>イベント名</th>
+      <th>開催日</th>
+      <th>作成日</th>
+      <th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @events.each do |event| %>
+      <tr>
+        <td><%= event.title %></td>
+        <td><%= event.held_on %></td>
+        <td><%= l(event.created_at, format: :short) %></td>
+        <td>
+          <%= link_to "詳細", admin_event_path(event) %> |
+          <%= link_to "編集", edit_admin_event_path(event) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -1,0 +1,3 @@
+<h1>新規イベント作成</h1>
+<%= render "form" %>
+<%= link_to "一覧へ戻る", admin_events_path %>

--- a/app/views/admin/events/new.html.erb
+++ b/app/views/admin/events/new.html.erb
@@ -1,3 +1,3 @@
 <h1>新規イベント作成</h1>
-<%= render "form" %>
+<%= render "form", event: @event %>
 <%= link_to "一覧へ戻る", admin_events_path %>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Admin::Events#show</h1>
+  <p>Find me in app/views/admin/events/show.html.erb</p>
+</div>

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -1,4 +1,11 @@
-<div>
-  <h1 class="font-bold text-4xl">Admin::Events#show</h1>
-  <p>Find me in app/views/admin/events/show.html.erb</p>
-</div>
+<h1><%= @event.name %></h1>
+
+<p>開催日：<%= @event.held_on %></p>
+<p>主催：<%= @event.organizer %></p>
+<p>対象：<%= @event.target %></p>
+<p><%= simple_format(@event.description) %></p>
+
+<p>
+  <%= link_to "編集", edit_admin_event_path(@event) %> |
+  <%= link_to "一覧へ戻る", admin_events_path %>
+</p>

--- a/app/views/admin/sessions/create.html.erb
+++ b/app/views/admin/sessions/create.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Admin::Sessions#create</h1>
+  <p>Find me in app/views/admin/sessions/create.html.erb</p>
+</div>

--- a/app/views/admin/sessions/destroy.html.erb
+++ b/app/views/admin/sessions/destroy.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Admin::Sessions#destroy</h1>
+  <p>Find me in app/views/admin/sessions/destroy.html.erb</p>
+</div>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,0 +1,19 @@
+<h1>管理ログイン</h1>
+
+<% if flash[:alert] %>
+  <p style="color:red"><%= flash[:alert] %></p>
+<% end %>
+
+<%= form_with url: admin_session_path, method: :post do %>
+  <div>
+    <label>メール</label>
+    <%= email_field_tag :email %>
+  </div>
+
+  <div>
+    <label>パスワード</label>
+    <%= password_field_tag :password %>
+  </div>
+
+  <%= submit_tag "ログイン" %>
+<% end %>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,18 +1,18 @@
 <h1>管理ログイン</h1>
 
-<% if flash[:alert] %>
+<% if flash[:alert].present? %>
   <p style="color:red"><%= flash[:alert] %></p>
 <% end %>
 
-<%= form_with url: admin_session_path, method: :post do %>
+<%= form_with url: admin_session_path, method: :post, data: { turbo: false } do %>
   <div>
-    <label>メール</label>
-    <%= email_field_tag :email %>
+    <%= label_tag :email, "メール" %><br>
+    <%= email_field_tag :email, nil, autocomplete: "email" %>
   </div>
 
   <div>
-    <label>パスワード</label>
-    <%= password_field_tag :password %>
+    <%= label_tag :password, "パスワード" %><br>
+    <%= password_field_tag :password, nil, autocomplete: "current-password" %>
   </div>
 
   <%= submit_tag "ログイン" %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Events#index</h1>
+  <p>Find me in app/views/events/index.html.erb</p>
+</div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,0 +1,4 @@
+<div>
+  <h1 class="font-bold text-4xl">Events#show</h1>
+  <p>Find me in app/views/events/show.html.erb</p>
+</div>

--- a/app/views/public/events/index.html.erb
+++ b/app/views/public/events/index.html.erb
@@ -1,0 +1,14 @@
+<h1>イベント一覧</h1>
+
+<% if @events.any? %>
+  <ul>
+    <% @events.each do |event| %>
+      <li>
+        <%= link_to event.title, event_path(event) %>
+        （開催日: <%= event.held_on %>）
+      </li>
+    <% end %>
+  </ul>
+<% else %>
+  <p>イベントはまだありません。</p>
+<% end %>

--- a/app/views/public/events/show.html.erb
+++ b/app/views/public/events/show.html.erb
@@ -1,0 +1,11 @@
+<h1><%= @event.title %></h1>
+
+<p>開催日：<%= @event.held_on %></p>
+<p>主催：<%= @event.organizer_name %></p>
+<p>対象：<%= @event.target_department %></p>
+
+<hr>
+
+<p><%= simple_format(@event.description) %></p>
+
+<p><%= link_to "一覧に戻る", events_path %></p>

--- a/config/database.yml
+++ b/config/database.yml
@@ -20,14 +20,14 @@ default: &default
 development:
   <<: *default
   database: development
-  host: postgres
+  host: localhost
   username: postgres
   password: postgres
 
 test:
   <<: *default
   database: test
-  host: postgres
+  host: localhost
   username: postgres
   password: postgres
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,7 @@ development:
   <<: *default
   database: development
   host: localhost
+  port: 5432
   username: postgres
   password: postgres
 
@@ -28,6 +29,7 @@ test:
   <<: *default
   database: test
   host: localhost
+  port: 5432
   username: postgres
   password: postgres
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,13 @@
 Rails.application.routes.draw do
-  # 公開側
+  namespace :admin do
+    resource :session, only: %i[new create destroy]
+    resources :events
+  end
+
   scope module: :public do
     resources :events, only: %i[index show]
   end
 
-  # 管理側
-  namespace :admin do
-    resources :events
-    resource :sessions, only: %i[new create destroy]
-  end
-
-  get "up" => "rails/health#show", as: :rails_health_check
-  get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
-  get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
+  # 必要なら（課題で指定があれば）
+  root "public/events#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,16 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  # 公開側
+  scope module: :public do
+    resources :events, only: %i[index show]
+  end
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  # 管理側
+  namespace :admin do
+    resources :events
+    resource :sessions, only: %i[new create destroy]
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/db/migrate/20260131024006_create_events.rb
+++ b/db/migrate/20260131024006_create_events.rb
@@ -1,0 +1,13 @@
+class CreateEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :events do |t|
+      t.string :title
+      t.text :description
+      t.date :held_on
+      t.string :organizer_name
+      t.string :target_department
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260131055921_create_admin_users.rb
+++ b/db/migrate/20260131055921_create_admin_users.rb
@@ -1,0 +1,11 @@
+class CreateAdminUsers < ActiveRecord::Migration[7.2]
+  def change
+    create_table :admin_users do |t|
+      t.string :email
+      t.string :password_digest
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260131062857_add_discarded_at_to_events.rb
+++ b/db/migrate/20260131062857_add_discarded_at_to_events.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtToEvents < ActiveRecord::Migration[7.2]
+  def change
+    add_column :events, :discarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_31_055921) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_31_062857) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,5 +30,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_01_31_055921) do
     t.string "target_department"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "discarded_at"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_01_31_024006) do
+ActiveRecord::Schema[7.2].define(version: 2026_01_31_055921) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "admin_users", force: :cascade do |t|
+    t.string "email"
+    t.string "password_digest"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "title"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,26 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2026_01_31_024006) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "events", force: :cascade do |t|
+    t.string "title"
+    t.text "description"
+    t.date "held_on"
+    t.string "organizer_name"
+    t.string "target_department"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,9 @@
 #   ["Action", "Comedy", "Drama", "Horror"].each do |genre_name|
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
+
+AdminUser.find_or_create_by!(email: "admin@example.com") do |u|
+  u.name = "社内推進チーム"
+  u.password = "password"
+  u.password_confirmation = "password"
+end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :admin_user do
+    email { "MyString" }
+    password_digest { "MyString" }
+    name { "MyString" }
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :event do
+    title { "MyString" }
+    description { "MyText" }
+    held_on { "2026-01-31" }
+    organizer_name { "MyString" }
+    target_department { "MyString" }
+  end
+end

--- a/spec/helpers/admin/events_helper_spec.rb
+++ b/spec/helpers/admin/events_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Admin::EventsHelper. For example:
+#
+# describe Admin::EventsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Admin::EventsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/admin/sessions_helper_spec.rb
+++ b/spec/helpers/admin/sessions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Admin::SessionsHelper. For example:
+#
+# describe Admin::SessionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Admin::SessionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the EventsHelper. For example:
+#
+# describe EventsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe EventsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/public/events_helper_spec.rb
+++ b/spec/helpers/public/events_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Public::EventsHelper. For example:
+#
+# describe Public::EventsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Public::EventsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/admin_user_spec.rb
+++ b/spec/models/admin_user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe AdminUser, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/admin/events_spec.rb
+++ b/spec/requests/admin/events_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Events", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/admin/events/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/admin/events/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /new" do
+    it "returns http success" do
+      get "/admin/events/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /edit" do
+    it "returns http success" do
+      get "/admin/events/edit"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/admin/sessions_spec.rb
+++ b/spec/requests/admin/sessions_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe "Admin::Sessions", type: :request do
+  describe "GET /new" do
+    it "returns http success" do
+      get "/admin/sessions/new"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /create" do
+    it "returns http success" do
+      get "/admin/sessions/create"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /destroy" do
+    it "returns http success" do
+      get "/admin/sessions/destroy"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Events", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/events/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/events/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/requests/public/events_spec.rb
+++ b/spec/requests/public/events_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe "Public::Events", type: :request do
+  describe "GET /index" do
+    it "returns http success" do
+      get "/public/events/index"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+  describe "GET /show" do
+    it "returns http success" do
+      get "/public/events/show"
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/views/admin/events/edit.html.tailwindcss_spec.rb
+++ b/spec/views/admin/events/edit.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/edit.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/events/index.html.tailwindcss_spec.rb
+++ b/spec/views/admin/events/index.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/index.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/events/new.html.tailwindcss_spec.rb
+++ b/spec/views/admin/events/new.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/new.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/events/show.html.tailwindcss_spec.rb
+++ b/spec/views/admin/events/show.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/show.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/sessions/create.html.tailwindcss_spec.rb
+++ b/spec/views/admin/sessions/create.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "sessions/create.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/sessions/destroy.html.tailwindcss_spec.rb
+++ b/spec/views/admin/sessions/destroy.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "sessions/destroy.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/admin/sessions/new.html.tailwindcss_spec.rb
+++ b/spec/views/admin/sessions/new.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "sessions/new.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/events/index.html.tailwindcss_spec.rb
+++ b/spec/views/events/index.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/index.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/events/show.html.tailwindcss_spec.rb
+++ b/spec/views/events/show.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/show.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/public/events/index.html.tailwindcss_spec.rb
+++ b/spec/views/public/events/index.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/index.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/public/events/show.html.tailwindcss_spec.rb
+++ b/spec/views/public/events/show.html.tailwindcss_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/show.html.tailwindcss", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
シナリオ1「管理画面でのイベント管理機能」の実装を進めました。
管理ログイン、イベントのCRUD、公開ページでの一覧・詳細表示まで対応しています。

---

## 実装内容

### 管理機能（admin）
- 管理ログイン画面の作成
- 管理ユーザー（AdminUser）のseed登録
- 管理画面でのイベントCRUD
  - 一覧表示
  - 新規作成
  - 編集
  - 詳細表示
  - 論理削除（discarded_at）

### 公開機能（public）
- イベント一覧ページ（/events）
- イベント詳細ページ（/events/:id）
- 論理削除されたイベントは非表示

---

## シナリオ1 実装チェックリスト

- [x] クローンしたリポジトリの立ち上げに成功している
- [x] 管理ページにログインするためのフォームが存在する
- [x] 初期データとして社内推進チームのメンバー情報が登録できる
- [x] 社内推進チームメンバーが実際にログインできる（※下記課題あり）
- [x] ログイン処理の成功・失敗が実装されている
- [x] 登録されたイベントの一覧が管理画面で確認できる
- [x] 新しくイベントを登録できる
- [x] 登録できない場合のエラー表示が存在する
- [x] 登録されたイベントを更新できる
- [x] 登録されたイベントを論理削除できる
- [x] 登録されたイベントの詳細ページが存在する
- [x] 管理画面には登録メンバーしかアクセスできないようになっている
- [x] 登録されたイベント詳細ページは誰でも見られるようになっている

---

## 現在の課題 / 確認してほしい点

- 管理ログイン時、POST `/admin/session` が **422 Unprocessable Content** になるケースがある
  - フォーム送信時に `email / password` が空で送信される場合がある
  - `form_with` の指定や params の扱いについてレビューいただきたい

---

## 動作確認

- `/events`：一覧表示 OK
- `/events/:id`：詳細表示 OK
- `/admin/session/new`：ログイン画面表示 OK
- 管理イベントCRUD：画面表示・操作 OK（ログイン状態時）

---

## 補足
まだWIPのため、マージは想定していません。
設計・実装方針や修正点についてレビューいただけると助かります。
<img width="960" height="504" alt="スクリーンショット 2026-01-31 163658" src="https://github.com/user-attachments/assets/f5f3722d-aa1b-4fea-930b-9dec8161f3cc" />
<img width="960" height="504" alt="スクリーンショット 2026-01-31 163714" src="https://github.com/user-attachments/assets/b4037d59-46df-4299-9f0d-4552643ae1f3" />
<img width="960" height="504" alt="スクリーンショット 2026-01-31 163743" src="https://github.com/user-attachments/assets/d827bb71-e0a3-420e-b550-ea97699f5da0" />
<img width="960" height="504" alt="スクリーンショット 2026-01-31 163815" src="https://github.com/user-attachments/assets/da7a431e-8af4-4aa7-ab72-8a40464c6987" />